### PR TITLE
feat: add SSO authentication support

### DIFF
--- a/.sdm-ui.yaml
+++ b/.sdm-ui.yaml
@@ -1,2 +1,3 @@
 email: "some.account@example.com"
 verbose: true
+useSSO: true

--- a/cmd/dmenu.go
+++ b/cmd/dmenu.go
@@ -58,6 +58,7 @@ var dmenuCmd = &cobra.Command{
 			app.WithVerbose(confData.Verbose),
 			app.WithDbPath(confData.DBPath),
 			app.WithBlacklist(confData.BlacklistPatterns),
+			app.WithSSO(confData.UseSSO),
 			commandOption,
 			app.WithTimeout(30*time.Second),
 		)

--- a/cmd/fzf.go
+++ b/cmd/fzf.go
@@ -48,6 +48,7 @@ var fzfCmd = &cobra.Command{
 			app.WithCommand(app.DMenuCommandNoop),
 			app.WithPasswordCommand(app.PasswordCommandCLI),
 			app.WithTimeout(30*time.Second),
+			app.WithSSO(confData.UseSSO),
 		)
 		if err != nil {
 			log.Error().Err(err).Msg("Failed to initialize application")

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -31,21 +31,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// listCmd represents the list command
-var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List SDM resources",
-	Long:  `Displays all available SDM resources in a formatted table.`,
-	Example: `  # List all SDM resources
-  sdm-ui list`,
-	Aliases: []string{"ls"},
+// logOutCmd represents the logout command
+var logOutCmd = &cobra.Command{
+	Use:     "logout",
+	Short:   "Log out of SDM UI",
+	Long:    `Logs out of SDM UI by deleting the cache database and forcing a fresh synchronization on next use.`,
+	Example: ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create application instance
 		application, err := app.NewApp(
 			app.WithAccount(confData.Email),
 			app.WithVerbose(confData.Verbose),
 			app.WithDbPath(confData.DBPath),
-			app.WithBlacklist(confData.BlacklistPatterns),
 			app.WithCommand(app.DMenuCommandNoop),
 			app.WithPasswordCommand(app.PasswordCommandCLI),
 			app.WithSSO(confData.UseSSO),
@@ -64,9 +61,9 @@ var listCmd = &cobra.Command{
 			}
 		}()
 
-		// Run list command with error handling
-		if err := application.List(os.Stdout, true); err != nil {
-			log.Error().Err(err).Msg("List operation failed")
+		// Run wipe command with error handling
+		if err := application.Logout(); err != nil {
+			log.Error().Err(err).Msg("Failed to log out")
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
@@ -74,5 +71,9 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(logOutCmd)
+
+	// Add usage examples to help text
+	dmenuCmd.Example = `  # Log out
+  sdm-ui logout`
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/adrg/xdg"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -37,6 +36,7 @@ type config struct {
 	Email             string   `mapstructure:"email"`
 	DBPath            string   `mapstructure:"dbPath"`
 	Verbose           bool     `mapstructure:"verbose"`
+	UseSSO            bool     `mapstructure:"useSSO"`
 	BlacklistPatterns []string `mapstructure:"blacklistPatterns"`
 }
 
@@ -47,6 +47,7 @@ var (
 		Email:             "",
 		DBPath:            xdg.DataHome,
 		Verbose:           false,
+		UseSSO:            false,
 		BlacklistPatterns: []string{},
 	}
 )
@@ -79,13 +80,11 @@ func Execute() {
 // init sets up flags and configuration
 func init() {
 	defaultConfigPath := filepath.Join(xdg.ConfigHome, "sdm-ui.yaml")
-
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", defaultConfigPath, "config file path")
 	rootCmd.PersistentFlags().StringVarP(&confData.Email, "email", "e", "", "email address")
 	rootCmd.PersistentFlags().BoolVarP(&confData.Verbose, "verbose", "v", false, "enable verbose output")
 	rootCmd.PersistentFlags().StringVarP(&confData.DBPath, "db", "d", xdg.DataHome, "database path")
-
-	rootCmd.MarkPersistentFlagRequired("email")
+	rootCmd.PersistentFlags().BoolVarP(&confData.UseSSO, "sso", "s", false, "use SSO")
 }
 
 // loadConfig loads configuration from file and environment
@@ -106,18 +105,28 @@ func loadConfig(cmd *cobra.Command) error {
 		}
 	}
 
-	cmd.Flags().Visit(func(f *pflag.Flag) {
-		viper.Set(f.Name, f.Value.String())
-	})
+	if err := viper.BindPFlag("email", cmd.Flags().Lookup("email")); err != nil {
+		return fmt.Errorf("failed to bind email flag: %w", err)
+	}
+	if err := viper.BindPFlag("verbose", cmd.Flags().Lookup("verbose")); err != nil {
+		return fmt.Errorf("failed to bind verbose flag: %w", err)
+	}
+	if err := viper.BindPFlag("dbPath", cmd.Flags().Lookup("db")); err != nil {
+		return fmt.Errorf("failed to bind db flag: %w", err)
+	}
+	if err := viper.BindPFlag("useSSO", cmd.Flags().Lookup("sso")); err != nil {
+		return fmt.Errorf("failed to bind sso flag: %w", err)
+	}
 
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		if !f.Changed && viper.IsSet(f.Name) {
-			val := viper.Get(f.Name)
-			cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
-		}
-	})
+	if err := viper.Unmarshal(&confData); err != nil {
+		return fmt.Errorf("could not unmarshal config: %w", err)
+	}
 
 	confData.BlacklistPatterns = viper.GetStringSlice("blacklistPatterns")
+
+	if confData.Email == "" {
+		return fmt.Errorf("email is required (provide via --email flag or config file)")
+	}
 
 	return nil
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -45,6 +45,7 @@ var syncCmd = &cobra.Command{
 			app.WithBlacklist(confData.BlacklistPatterns),
 			app.WithCommand(app.DMenuCommandNoop),
 			app.WithPasswordCommand(app.PasswordCommandCLI),
+			app.WithSSO(confData.UseSSO),
 			app.WithTimeout(30*time.Second),
 		)
 		if err != nil {

--- a/cmd/wipe.go
+++ b/cmd/wipe.go
@@ -46,6 +46,7 @@ var wipeCmd = &cobra.Command{
 			app.WithDbPath(confData.DBPath),
 			app.WithCommand(app.DMenuCommandNoop),
 			app.WithPasswordCommand(app.PasswordCommandCLI),
+			app.WithSSO(confData.UseSSO),
 			app.WithTimeout(30*time.Second),
 		)
 		if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,6 +23,7 @@ var ErrResourceNotFound = errors.New("resource not found")
 // App represents the main application structure
 type App struct {
 	account string
+	useSSO  bool
 
 	db              *storage.Storage
 	dbPath          string
@@ -92,6 +93,14 @@ func WithTimeout(timeout time.Duration) AppOption {
 func WithContext(ctx context.Context) AppOption {
 	return func(p *App) {
 		p.context = ctx
+	}
+}
+
+// WithSSO enables SSO authentication
+func WithSSO(useSSO bool) AppOption {
+	return func(p *App) {
+		p.useSSO = useSSO
+		log.Debug().Bool("useSSO", useSSO).Msg("SSO authentication configured")
 	}
 }
 
@@ -227,25 +236,14 @@ func (p *App) RetryCommand(exec func() error) error {
 // HandleUnauthorized handles unauthorized errors by re-authenticating
 func (p *App) handleUnauthorized(command func() error) error {
 	notify.Notify("SDM CLI", "🔐 Authenticating...", "", "")
-
-	password, err := p.retrievePassword()
-	if err != nil {
+	if err := p.authenticateUser(); err != nil {
+		if !p.useSSO {
+			p.keyring.DeleteSecret(p.account)
+		}
 		notify.Notify("SDM CLI", "🔐 Authentication error", err.Error(), "")
-		return fmt.Errorf("failed to retrieve password: %w", err)
+		return fmt.Errorf("authentication failed: %w", err)
 	}
-
-	log.Debug().Msg("Logging in...")
-
-	ctx, cancel := context.WithTimeout(p.context, p.timeout)
-	defer cancel()
-
-	if err := p.sdmWrapper.LoginWithContext(ctx, p.account, password); err != nil {
-		p.keyring.DeleteSecret(p.account)
-		notify.Notify("SDM CLI", "🔐 Authentication error", err.Error(), "")
-		return fmt.Errorf("login failed: %w", err)
-	}
-
-	log.Debug().Msg("Login successful")
+	log.Debug().Msg("Authentication successful")
 	return command()
 }
 
@@ -254,4 +252,8 @@ func (p *App) handleInvalidCredentials(err sdm.SDMError) error {
 	notify.Notify("SDM CLI", "🔐 Authentication error", "Invalid credentials", "")
 	p.keyring.DeleteSecret(p.account)
 	return fmt.Errorf("invalid credentials: %w", err)
+}
+
+func (p *App) Logout() error {
+	return p.sdmWrapper.Logout()
 }

--- a/internal/app/password.go
+++ b/internal/app/password.go
@@ -29,6 +29,27 @@ const (
 	PasswordCommandCLI    PasswordCommand = "cli"    // Use CLI prompt for password
 )
 
+func (p *App) tryKeyringWithTimeout(account string, timeout time.Duration) (string, error) {
+	type result struct {
+		password string
+		err      error
+	}
+
+	resultChan := make(chan result, 1)
+
+	go func() {
+		password, err := p.keyring.GetSecret(account)
+		resultChan <- result{password: password, err: err}
+	}()
+
+	select {
+	case res := <-resultChan:
+		return res.password, res.err
+	case <-time.After(timeout):
+		return "", errors.New("keyring operation timed out - keyring service may not be available")
+	}
+}
+
 // retrievePassword attempts to retrieve the password from the keyring.
 // If the password is not found or an error occurs, it prompts the user to enter the password.
 func (p *App) retrievePassword() (string, error) {
@@ -44,7 +65,7 @@ func (p *App) retrievePassword() (string, error) {
 	defer cancel()
 
 	// Attempt to retrieve the password from the keyring
-	password, err := p.keyring.GetSecret(p.account)
+	password, err := p.tryKeyringWithTimeout(p.account, 2*time.Second)
 	if err == nil && password != "" {
 		log.Debug().Str("account", p.account).Msg("Password retrieved from keyring")
 		return password, nil
@@ -131,5 +152,30 @@ func (p *App) askForPassword(pc PasswordCommand) (string, error) {
 	default:
 		log.Error().Str("command", string(pc)).Msg("Unknown password command")
 		return "", fmt.Errorf("%w: %s", ErrUnknownPasswordCmd, pc)
+	}
+}
+
+// authenticateUser handles both SSO and password-based authentication
+func (p *App) authenticateUser() error {
+	if p.account == "" {
+		log.Error().Msg("No account provided")
+		return fmt.Errorf("no account provided")
+	}
+
+	ctx, cancel := context.WithTimeout(p.context, p.timeout)
+	defer cancel()
+
+	if p.useSSO {
+		log.Debug().Msg("Using SSO authentication")
+		// Empty password = SSO
+		return p.sdmWrapper.LoginWithContext(ctx, p.account, "")
+	} else {
+		log.Debug().Msg("Using password authentication")
+		password, err := p.retrievePassword()
+		if err != nil {
+			return fmt.Errorf("failed to retrieve password: %w", err)
+		}
+		// Provided password = password auth
+		return p.sdmWrapper.LoginWithContext(ctx, p.account, password)
 	}
 }

--- a/internal/sdm/sdm.go
+++ b/internal/sdm/sdm.go
@@ -125,25 +125,35 @@ func (s *SDMClient) Logout() error {
 	return s.LogoutWithContext(context.Background())
 }
 
-// LoginWithContext logs in the user with the provided email and password using the provided context
+// LoginWithContext logs in the user with optional password (empty password = SSO)
 func (s *SDMClient) LoginWithContext(ctx context.Context, email, password string) error {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
 
-	stdin := strings.NewReader(password + "\n")
 	var output strings.Builder
-
-	err := s.CommandRunner.RunCommandWithContext(
-		ctxWithTimeout,
+	options := []cmder.CommandOption{
 		cmder.WithArgs("login", "--email", email),
-		cmder.WithStdin(stdin),
 		cmder.WithOutput(&output),
 		cmder.WithErrorParser(parseSdmError),
-	)
+	}
+
+	// Add password via stdin if provided (password auth), otherwise use SSO
+	if password != "" {
+		stdin := strings.NewReader(password + "\n")
+		options = append(options, cmder.WithStdin(stdin))
+	}
+
+	err := s.CommandRunner.RunCommandWithContext(ctxWithTimeout, options...)
 	if err != nil {
+		authType := "SSO"
+		if password != "" {
+			authType = "Password"
+		}
+
 		log.Debug().
 			Err(err).
 			Str("email", email).
+			Str("auth_type", authType).
 			Str("output", output.String()).
 			Msg("Login failed")
 		return fmt.Errorf("login command failed: %w", err)
@@ -151,11 +161,6 @@ func (s *SDMClient) LoginWithContext(ctx context.Context, email, password string
 
 	log.Debug().Str("email", email).Msg("Login successful")
 	return nil
-}
-
-// Login logs in the user with the provided email and password
-func (s *SDMClient) Login(email, password string) error {
-	return s.LoginWithContext(context.Background(), email, password)
 }
 
 // StatusWithContext writes the status of the SDM client to the provided writer using the provided context


### PR DESCRIPTION
- Add UseSSO configuration option to support SSO authentication
- Update all commands (dmenu, fzf, list, sync, wipe) to pass SSO config
- Add new logout command that calls SDM logout functionality
- Modify authentication flow to handle both password and SSO modes
- Update SDM client to support passwordless login for SSO
- Add keyring operation timeout to prevent hanging on unavailable keyring services
- Improve error handling and logging for different auth types

SSO authentication is enabled when UseSSO config is true and uses empty password for SDM login command. Password authentication remains the default when UseSSO is false.